### PR TITLE
Fix NoneType error in LiteLLM logging handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinybird-python-sdk"
-version = "0.3.5"
+version = "0.3.6"
 description = "Python SDK for Tinybird"
 readme = "README.md"
 authors = [

--- a/tb/litellm/handler.py
+++ b/tb/litellm/handler.py
@@ -48,6 +48,9 @@ class TinybirdLitellmHandler(CustomLogger):
         else:
             api_key = "****"
 
+        # Safely extract standard_logging_object with proper null checks
+        standard_logging_object = kwargs.get("standard_logging_object") or {}
+        
         data = {
             "model": kwargs.get("model"),
             "messages": kwargs.get("messages"),
@@ -62,21 +65,11 @@ class TinybirdLitellmHandler(CustomLogger):
             "llm_api_duration_ms": kwargs.get("llm_api_duration_ms"),
             "response_headers": kwargs.get("response_headers", {}),
             "cache_hit": kwargs.get("cache_hit", False),
-            "standard_logging_object_id": kwargs.get("standard_logging_object", {}).get(
-                "id"
-            ),
-            "standard_logging_object_status": kwargs.get(
-                "standard_logging_object", {}
-            ).get("status"),
-            "standard_logging_object_response_time": kwargs.get(
-                "standard_logging_object", {}
-            ).get("response_time"),
-            "standard_logging_object_saved_cache_cost": kwargs.get(
-                "standard_logging_object", {}
-            ).get("saved_cache_cost"),
-            "standard_logging_object_hidden_params": kwargs.get(
-                "standard_logging_object", {}
-            ).get("status"),
+            "standard_logging_object_id": standard_logging_object.get("id"),
+            "standard_logging_object_status": standard_logging_object.get("status"),
+            "standard_logging_object_response_time": standard_logging_object.get("response_time"),
+            "standard_logging_object_saved_cache_cost": standard_logging_object.get("saved_cache_cost"),
+            "standard_logging_object_hidden_params": standard_logging_object.get("status"),
             "api_key": api_key,
         }
 


### PR DESCRIPTION
Add null safety checks for standard_logging_object to prevent 'NoneType' object has no attribute 'get' errors when the object is None.

