### PR TITLE
Bump Tinybird CLI dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tinybird-sdk"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python SDK for Tinybird Forward"
 readme = "README.md"
 authors = [
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "tinybird==4.3.1",
+    "tinybird==4.4.1",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -936,7 +936,7 @@ wheels = [
 
 [[package]]
 name = "tinybird-sdk"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "tinybird" },


### PR DESCRIPTION
The 4.4.1 version includes adapted messages based on the sdk tool. Feedback errors will now show: `uv run tinybird x` instead of `tb x`