### PR TITLE
Allow to set branch mode in tinybird.config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
-- Bumped bundled `tinybird` CLI dependency to `4.6.1`.
+- Relaxed bundled `tinybird` CLI dependency to `>=4.6.0,<4.7.0` to avoid resolution failures while keeping the SDK on the `4.6.x` line.
 - Updated branch data config handling to use `branch_data_mode`; legacy `branch_data_on_create` now triggers an explicit migration error.
 - `branch_data_mode` now only accepts `last_partition` as a user-facing value.
 - In `dev_mode=local`, branch data mode warnings are now shown only when `branch_data_mode` is explicitly set in `tinybird.config.json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.11] - 2026-06-15
 
-### Added
-- Professional repository baseline:
-  - CI workflow with lint, type checks, tests, and secret scanning gates.
-  - `pre-commit` with `ruff`, `mypy`, and `gitleaks`.
-  - `Makefile`, `CODEOWNERS`, and PR template.
-  - Initial `SECURITY.md` and packaging metadata improvements.
+### Changed
+
+- Bumped bundled `tinybird` CLI dependency to `4.6.1`.
+- Updated branch data config handling to use `branch_data_mode`; legacy `branch_data_on_create` now triggers an explicit migration error.
+- `branch_data_mode` now only accepts `last_partition` as a user-facing value.
+- In `dev_mode=local`, branch data mode warnings are now shown only when `branch_data_mode` is explicitly set in `tinybird.config.json`.
+- `tinybird branch create` and `tinybird branch clear` now show a deprecation warning (instead of failing) when `--ignore-datasource` is passed, then continue by ignoring that flag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "tinybird==4.6.1",
+    "tinybird>=4.6.0,<4.7.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tinybird-sdk"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python SDK for Tinybird Forward"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "tinybird==4.6.0",
+    "tinybird==4.6.1",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/tinybird_sdk/api/__init__.py
+++ b/src/tinybird_sdk/api/__init__.py
@@ -13,6 +13,7 @@ from .fetcher import (
 )
 from .branches import (
     TinybirdBranch,
+    CreateBranchOptions,
     BranchApiConfig,
     BranchApiError,
     create_branch,

--- a/src/tinybird_sdk/api/branches.py
+++ b/src/tinybird_sdk/api/branches.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import time
-from dataclasses import asdict
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any
 from urllib.parse import urlencode
 
 from .fetcher import tinybird_fetch
+LAST_PARTITION = "last_partition"
+ALL_PARTITIONS = "all_partitions"
 
 LAST_PARTITION = "last_partition"
 
@@ -23,6 +24,12 @@ class TinybirdBranch:
     name: str
     created_at: str
     token: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CreateBranchOptions:
+    last_partition: bool = False
+    all_partitions: bool = False
 
 
 class BranchApiError(Exception):
@@ -68,9 +75,16 @@ def _poll_job(
     raise BranchApiError(f"Job '{job_id}' timed out after {max_attempts} attempts", 408)
 
 
-def create_branch(config: BranchApiConfig | dict[str, Any], name: str) -> TinybirdBranch:
+def create_branch(
+    config: BranchApiConfig | dict[str, Any], name: str, options: CreateBranchOptions | None = None
+) -> TinybirdBranch:
     normalized = config if isinstance(config, BranchApiConfig) else BranchApiConfig(**config)
-    url = f"{normalized.base_url.rstrip('/')}/v1/environments?{urlencode({'name': name})}"
+    params = {"name": name}
+    if options and options.last_partition:
+        params["data"] = LAST_PARTITION
+    elif options and options.all_partitions:
+        params["data"] = ALL_PARTITIONS
+    url = f"{normalized.base_url.rstrip('/')}/v1/environments?{urlencode(params)}"
     response = tinybird_fetch(url, method="POST", headers=_headers(normalized.token))
 
     if not response.ok:
@@ -152,14 +166,16 @@ def branch_exists(config: BranchApiConfig | dict[str, Any], name: str) -> bool:
     return any(branch.name == name for branch in branches)
 
 
-def get_or_create_branch(config: BranchApiConfig | dict[str, Any], name: str) -> dict[str, Any]:
+def get_or_create_branch(
+    config: BranchApiConfig | dict[str, Any], name: str, options: CreateBranchOptions | None = None
+) -> dict[str, Any]:
     normalized = config if isinstance(config, BranchApiConfig) else BranchApiConfig(**config)
     try:
         branch = get_branch(normalized, name)
         return {**asdict(branch), "was_created": False}
     except BranchApiError as error:
         if error.status == 404:
-            branch = create_branch(normalized, name)
+            branch = create_branch(normalized, name, options=options)
             return {**asdict(branch), "was_created": True}
         raise
 

--- a/src/tinybird_sdk/api/branches.py
+++ b/src/tinybird_sdk/api/branches.py
@@ -5,11 +5,8 @@ from dataclasses import asdict, dataclass
 from typing import Any
 from urllib.parse import urlencode
 
+from ..cli.config_types import BranchDataMode
 from .fetcher import tinybird_fetch
-
-LAST_PARTITION = "last_partition"
-
-LAST_PARTITION = "last_partition"
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,7 +25,7 @@ class TinybirdBranch:
 
 @dataclass(frozen=True, slots=True)
 class CreateBranchOptions:
-    last_partition: bool = False
+    branch_data_mode: BranchDataMode | None = None
 
 
 class BranchApiError(Exception):
@@ -79,8 +76,8 @@ def create_branch(
 ) -> TinybirdBranch:
     normalized = config if isinstance(config, BranchApiConfig) else BranchApiConfig(**config)
     params = {"name": name}
-    if options and options.last_partition:
-        params["data"] = LAST_PARTITION
+    if options and options.branch_data_mode:
+        params["data"] = options.branch_data_mode
     url = f"{normalized.base_url.rstrip('/')}/v1/environments?{urlencode(params)}"
     response = tinybird_fetch(url, method="POST", headers=_headers(normalized.token))
 

--- a/src/tinybird_sdk/api/branches.py
+++ b/src/tinybird_sdk/api/branches.py
@@ -6,6 +6,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 from .fetcher import tinybird_fetch
+
 LAST_PARTITION = "last_partition"
 
 LAST_PARTITION = "last_partition"

--- a/src/tinybird_sdk/api/branches.py
+++ b/src/tinybird_sdk/api/branches.py
@@ -7,7 +7,6 @@ from urllib.parse import urlencode
 
 from .fetcher import tinybird_fetch
 LAST_PARTITION = "last_partition"
-ALL_PARTITIONS = "all_partitions"
 
 LAST_PARTITION = "last_partition"
 
@@ -29,7 +28,6 @@ class TinybirdBranch:
 @dataclass(frozen=True, slots=True)
 class CreateBranchOptions:
     last_partition: bool = False
-    all_partitions: bool = False
 
 
 class BranchApiError(Exception):
@@ -82,8 +80,6 @@ def create_branch(
     params = {"name": name}
     if options and options.last_partition:
         params["data"] = LAST_PARTITION
-    elif options and options.all_partitions:
-        params["data"] = ALL_PARTITIONS
     url = f"{normalized.base_url.rstrip('/')}/v1/environments?{urlencode(params)}"
     response = tinybird_fetch(url, method="POST", headers=_headers(normalized.token))
 
@@ -180,7 +176,9 @@ def get_or_create_branch(
         raise
 
 
-def clear_branch(config: BranchApiConfig | dict[str, Any], name: str) -> TinybirdBranch:
+def clear_branch(
+    config: BranchApiConfig | dict[str, Any], name: str, options: CreateBranchOptions | None = None
+) -> TinybirdBranch:
     normalized = config if isinstance(config, BranchApiConfig) else BranchApiConfig(**config)
     delete_branch(normalized, name)
-    return create_branch(normalized, name)
+    return create_branch(normalized, name, options=options)

--- a/src/tinybird_sdk/cli/commands/build.py
+++ b/src/tinybird_sdk/cli/commands/build.py
@@ -139,11 +139,10 @@ def run_build(options: BuildCommandOptions | dict[str, Any] | None = None) -> Bu
         if not normalized.token_override:
             try:
                 branch_options = None
-                branch_value = config.get("branch_data_on_create")
+                branch_value = config.get("branch_data_mode")
                 if branch_value and config.get("dev_mode") != "local":
                     branch_options = CreateBranchOptions(
                         last_partition=(branch_value == "last_partition"),
-                        all_partitions=(branch_value == "all_partitions"),
                     )
                 branch = get_or_create_branch(
                     {"base_url": config["base_url"], "token": config["token"]},

--- a/src/tinybird_sdk/cli/commands/build.py
+++ b/src/tinybird_sdk/cli/commands/build.py
@@ -5,7 +5,7 @@ import os
 import time
 from typing import Any
 
-from ...api.branches import get_or_create_branch
+from ...api.branches import CreateBranchOptions, get_or_create_branch
 from ...api.build import build_to_tinybird
 from ...api.dashboard import get_branch_dashboard_url, get_local_dashboard_url
 from ...api.local import (
@@ -138,9 +138,17 @@ def run_build(options: BuildCommandOptions | dict[str, Any] | None = None) -> Bu
 
         if not normalized.token_override:
             try:
+                branch_options = None
+                branch_value = config.get("branch_data_on_create")
+                if branch_value and config.get("dev_mode") != "local":
+                    branch_options = CreateBranchOptions(
+                        last_partition=(branch_value == "last_partition"),
+                        all_partitions=(branch_value == "all_partitions"),
+                    )
                 branch = get_or_create_branch(
                     {"base_url": config["base_url"], "token": config["token"]},
                     config["tinybird_branch"],
+                    options=branch_options,
                 )
                 if not branch.get("token"):
                     return BuildCommandResult(

--- a/src/tinybird_sdk/cli/commands/build.py
+++ b/src/tinybird_sdk/cli/commands/build.py
@@ -141,9 +141,7 @@ def run_build(options: BuildCommandOptions | dict[str, Any] | None = None) -> Bu
                 branch_options = None
                 branch_value = config.get("branch_data_mode")
                 if branch_value and config.get("dev_mode") != "local":
-                    branch_options = CreateBranchOptions(
-                        last_partition=(branch_value == "last_partition"),
-                    )
+                    branch_options = CreateBranchOptions(branch_data_mode=branch_value)
                 branch = get_or_create_branch(
                     {"base_url": config["base_url"], "token": config["token"]},
                     config["tinybird_branch"],

--- a/src/tinybird_sdk/cli/commands/clear.py
+++ b/src/tinybird_sdk/cli/commands/clear.py
@@ -63,7 +63,7 @@ def run_clear(options: ClearCommandOptions | dict[str, Any] | None = None) -> Cl
         branch_options = None
         branch_value = config.get("branch_data_mode")
         if branch_value and config.get("dev_mode") != "local":
-            branch_options = CreateBranchOptions(last_partition=(branch_value == "last_partition"))
+            branch_options = CreateBranchOptions(branch_data_mode=branch_value)
 
         clear_branch(
             {"base_url": config["base_url"], "token": config["token"]},

--- a/src/tinybird_sdk/cli/commands/clear.py
+++ b/src/tinybird_sdk/cli/commands/clear.py
@@ -5,7 +5,7 @@ import os
 import time
 from typing import Any
 
-from ...api.branches import clear_branch
+from ...api.branches import CreateBranchOptions, clear_branch
 from ...api.local import clear_local_workspace, get_local_tokens, get_local_workspace_name
 from ..config import load_config_async
 
@@ -60,8 +60,15 @@ def run_clear(options: ClearCommandOptions | dict[str, Any] | None = None) -> Cl
                 duration_ms=int(time.time() * 1000) - start,
             )
 
+        branch_options = None
+        branch_value = config.get("branch_data_mode")
+        if branch_value and config.get("dev_mode") != "local":
+            branch_options = CreateBranchOptions(last_partition=(branch_value == "last_partition"))
+
         clear_branch(
-            {"base_url": config["base_url"], "token": config["token"]}, config["tinybird_branch"]
+            {"base_url": config["base_url"], "token": config["token"]},
+            config["tinybird_branch"],
+            options=branch_options,
         )
         return ClearResult(
             success=True,

--- a/src/tinybird_sdk/cli/commands/preview.py
+++ b/src/tinybird_sdk/cli/commands/preview.py
@@ -5,7 +5,7 @@ import os
 import time
 from typing import Any
 
-from ...api.branches import create_branch, delete_branch, get_branch
+from ...api.branches import CreateBranchOptions, create_branch, delete_branch, get_branch
 from ...api.build import build_to_tinybird
 from ...api.deploy import deploy_to_main
 from ...api.local import LocalNotRunningError, get_local_tokens, get_or_create_local_workspace
@@ -151,8 +151,17 @@ def run_preview(
         except Exception:
             pass
 
+        branch_options = None
+        branch_value = config.get("branch_data_on_create")
+        if branch_value and config.get("dev_mode") != "local":
+            branch_options = CreateBranchOptions(
+                last_partition=(branch_value == "last_partition"),
+                all_partitions=(branch_value == "all_partitions"),
+            )
         branch = create_branch(
-            {"base_url": config["base_url"], "token": config["token"]}, preview_branch_name
+            {"base_url": config["base_url"], "token": config["token"]},
+            preview_branch_name,
+            options=branch_options,
         )
     except Exception as error:
         return PreviewCommandResult(

--- a/src/tinybird_sdk/cli/commands/preview.py
+++ b/src/tinybird_sdk/cli/commands/preview.py
@@ -154,9 +154,7 @@ def run_preview(
         branch_options = None
         branch_value = config.get("branch_data_mode")
         if branch_value and config.get("dev_mode") != "local":
-            branch_options = CreateBranchOptions(
-                last_partition=(branch_value == "last_partition"),
-            )
+            branch_options = CreateBranchOptions(branch_data_mode=branch_value)
         branch = create_branch(
             {"base_url": config["base_url"], "token": config["token"]},
             preview_branch_name,

--- a/src/tinybird_sdk/cli/commands/preview.py
+++ b/src/tinybird_sdk/cli/commands/preview.py
@@ -152,11 +152,10 @@ def run_preview(
             pass
 
         branch_options = None
-        branch_value = config.get("branch_data_on_create")
+        branch_value = config.get("branch_data_mode")
         if branch_value and config.get("dev_mode") != "local":
             branch_options = CreateBranchOptions(
                 last_partition=(branch_value == "last_partition"),
-                all_partitions=(branch_value == "all_partitions"),
             )
         branch = create_branch(
             {"base_url": config["base_url"], "token": config["token"]},

--- a/src/tinybird_sdk/cli/config.py
+++ b/src/tinybird_sdk/cli/config.py
@@ -8,7 +8,12 @@ from pathlib import Path
 from typing import Any
 
 from .config_loader import load_config_file
-from .config_types import DevMode, TinybirdConfig
+from .config_types import (
+    BRANCH_DATA_ON_CREATE_VALUES,
+    BranchDataOnCreateMode,
+    DevMode,
+    TinybirdConfig,
+)
 from .git import get_current_git_branch, get_tinybird_branch_name, is_main_branch
 
 DEFAULT_BASE_URL = "https://api.tinybird.co"
@@ -34,6 +39,26 @@ class ResolvedConfig:
     tinybird_branch: str | None
     is_main_branch: bool
     dev_mode: DevMode
+    branch_data_on_create: str | None
+
+
+def _resolve_branch_data_on_create(raw: dict[str, Any]) -> str | None:
+    value = raw.get("branch_data_on_create")
+    if value is None:
+        return BranchDataOnCreateMode.LAST_PARTITION.value
+    if not isinstance(value, str):
+        raise ValueError("branch_data_on_create must be a string.")
+
+    mode = value.strip().lower()
+    if not mode:
+        return BranchDataOnCreateMode.LAST_PARTITION.value
+    if mode not in BRANCH_DATA_ON_CREATE_VALUES:
+        raise ValueError(
+            f"Invalid branch_data_on_create '{value}'. Allowed values are: {', '.join(BRANCH_DATA_ON_CREATE_VALUES)}."
+        )
+    if mode == BranchDataOnCreateMode.ALL_PARTITIONS.value:
+        raise ValueError("branch_data_on_create 'all_partitions' is currently disabled.")
+    return mode
 
 
 def load_env_files(directory: str) -> None:
@@ -176,6 +201,14 @@ def _resolve_config(config: TinybirdConfig, config_path: str) -> ResolvedConfig:
         or DEFAULT_BASE_URL
     )
 
+    branch_data_on_create = _resolve_branch_data_on_create(asdict(config))
+    dev_mode = config.dev_mode or "branch"
+    if branch_data_on_create and dev_mode == "local":
+        print(
+            "Warning: branch_data_on_create is set in tinybird.config.json but dev_mode='local'. "
+            "Branch data settings only apply to cloud branches."
+        )
+
     return ResolvedConfig(
         include=include,
         token=token,
@@ -185,7 +218,8 @@ def _resolve_config(config: TinybirdConfig, config_path: str) -> ResolvedConfig:
         git_branch=get_current_git_branch(),
         tinybird_branch=get_tinybird_branch_name(),
         is_main_branch=is_main_branch(),
-        dev_mode=config.dev_mode or "branch",
+        dev_mode=dev_mode,
+        branch_data_on_create=branch_data_on_create,
     )
 
 

--- a/src/tinybird_sdk/cli/config.py
+++ b/src/tinybird_sdk/cli/config.py
@@ -9,8 +9,8 @@ from typing import Any
 
 from .config_loader import load_config_file
 from .config_types import (
-    BRANCH_DATA_ON_CREATE_VALUES,
-    BranchDataOnCreateMode,
+    BRANCH_DATA_MODE_VALUES,
+    BranchDataModeEnum,
     DevMode,
     TinybirdConfig,
 )
@@ -39,26 +39,27 @@ class ResolvedConfig:
     tinybird_branch: str | None
     is_main_branch: bool
     dev_mode: DevMode
-    branch_data_on_create: str | None
+    branch_data_mode: str | None
 
 
-def _resolve_branch_data_on_create(raw: dict[str, Any]) -> str | None:
-    value = raw.get("branch_data_on_create")
+def _resolve_branch_data_mode(raw: dict[str, Any]) -> tuple[str | None, bool]:
+    if "branch_data_on_create" in raw:
+        raise ValueError("`branch_data_on_create` has been renamed to `branch_data_mode`.")
+
+    value = raw.get("branch_data_mode")
     if value is None:
-        return BranchDataOnCreateMode.LAST_PARTITION.value
+        return BranchDataModeEnum.LAST_PARTITION.value, False
     if not isinstance(value, str):
-        raise ValueError("branch_data_on_create must be a string.")
+        raise ValueError("branch_data_mode must be a string.")
 
     mode = value.strip().lower()
     if not mode:
-        return BranchDataOnCreateMode.LAST_PARTITION.value
-    if mode not in BRANCH_DATA_ON_CREATE_VALUES:
+        return BranchDataModeEnum.LAST_PARTITION.value, False
+    if mode not in BRANCH_DATA_MODE_VALUES:
         raise ValueError(
-            f"Invalid branch_data_on_create '{value}'. Allowed values are: {', '.join(BRANCH_DATA_ON_CREATE_VALUES)}."
+            f"Invalid branch_data_mode '{value}'. Allowed values are: {', '.join(BRANCH_DATA_MODE_VALUES)}."
         )
-    if mode == BranchDataOnCreateMode.ALL_PARTITIONS.value:
-        raise ValueError("branch_data_on_create 'all_partitions' is currently disabled.")
-    return mode
+    return mode, True
 
 
 def load_env_files(directory: str) -> None:
@@ -201,11 +202,11 @@ def _resolve_config(config: TinybirdConfig, config_path: str) -> ResolvedConfig:
         or DEFAULT_BASE_URL
     )
 
-    branch_data_on_create = _resolve_branch_data_on_create(asdict(config))
+    branch_data_mode, branch_data_mode_explicit = _resolve_branch_data_mode(asdict(config))
     dev_mode = config.dev_mode or "branch"
-    if branch_data_on_create and dev_mode == "local":
+    if branch_data_mode_explicit and branch_data_mode and dev_mode == "local":
         print(
-            "Warning: branch_data_on_create is set in tinybird.config.json but dev_mode='local'. "
+            "Warning: branch_data_mode is set in tinybird.config.json but dev_mode='local'. "
             "Branch data settings only apply to cloud branches."
         )
 
@@ -219,7 +220,7 @@ def _resolve_config(config: TinybirdConfig, config_path: str) -> ResolvedConfig:
         tinybird_branch=get_tinybird_branch_name(),
         is_main_branch=is_main_branch(),
         dev_mode=dev_mode,
-        branch_data_on_create=branch_data_on_create,
+        branch_data_mode=branch_data_mode,
     )
 
 

--- a/src/tinybird_sdk/cli/config_types.py
+++ b/src/tinybird_sdk/cli/config_types.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Literal
 
 DevMode = Literal["branch", "local"]
+BranchDataOnCreate = Literal["last_partition", "all_partitions"]
+BRANCH_DATA_ON_CREATE_VALUES: tuple[str, ...] = ("last_partition", "all_partitions")
+
+
+class BranchDataOnCreateMode(StrEnum):
+    LAST_PARTITION = "last_partition"
+    ALL_PARTITIONS = "all_partitions"
 
 
 @dataclass(frozen=True, slots=True)
@@ -13,3 +21,4 @@ class TinybirdConfig:
     token: str | None = None
     base_url: str | None = None
     dev_mode: DevMode | None = None
+    branch_data_on_create: str | None = None

--- a/src/tinybird_sdk/cli/config_types.py
+++ b/src/tinybird_sdk/cli/config_types.py
@@ -5,13 +5,12 @@ from enum import StrEnum
 from typing import Literal
 
 DevMode = Literal["branch", "local"]
-BranchDataOnCreate = Literal["last_partition", "all_partitions"]
-BRANCH_DATA_ON_CREATE_VALUES: tuple[str, ...] = ("last_partition", "all_partitions")
+BranchDataMode = Literal["last_partition"]
+BRANCH_DATA_MODE_VALUES: tuple[str, ...] = ("last_partition",)
 
 
-class BranchDataOnCreateMode(StrEnum):
+class BranchDataModeEnum(StrEnum):
     LAST_PARTITION = "last_partition"
-    ALL_PARTITIONS = "all_partitions"
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,4 +20,4 @@ class TinybirdConfig:
     token: str | None = None
     base_url: str | None = None
     dev_mode: DevMode | None = None
-    branch_data_on_create: str | None = None
+    branch_data_mode: str | None = None

--- a/src/tinybird_sdk/client/base.py
+++ b/src/tinybird_sdk/client/base.py
@@ -162,9 +162,7 @@ class TinybirdClient:
             branch_options = None
             branch_value = config.get("branch_data_mode")
             if branch_value and config.get("dev_mode") != "local":
-                branch_options = CreateBranchOptions(
-                    last_partition=(branch_value == "last_partition")
-                )
+                branch_options = CreateBranchOptions(branch_data_mode=branch_value)
 
             branch = get_or_create_branch(
                 {

--- a/src/tinybird_sdk/client/base.py
+++ b/src/tinybird_sdk/client/base.py
@@ -4,7 +4,7 @@ from dataclasses import asdict
 from typing import Any, cast
 
 from ..api.api import TinybirdApi, TinybirdApiError
-from ..api.branches import get_or_create_branch
+from ..api.branches import CreateBranchOptions, get_or_create_branch
 from ..cli.config import load_config_async
 from .preview import get_preview_branch_name, is_preview_environment
 from .tokens import TokensNamespace
@@ -159,12 +159,18 @@ class TinybirdClient:
                 )
 
             branch_name = config["tinybird_branch"]
+            branch_options = None
+            branch_value = config.get("branch_data_mode")
+            if branch_value and config.get("dev_mode") != "local":
+                branch_options = CreateBranchOptions(last_partition=(branch_value == "last_partition"))
+
             branch = get_or_create_branch(
                 {
                     "base_url": self._config["base_url"],
                     "token": self._config["token"],
                 },
                 branch_name,
+                options=branch_options,
             )
 
             if not branch.get("token"):

--- a/src/tinybird_sdk/client/base.py
+++ b/src/tinybird_sdk/client/base.py
@@ -162,7 +162,9 @@ class TinybirdClient:
             branch_options = None
             branch_value = config.get("branch_data_mode")
             if branch_value and config.get("dev_mode") != "local":
-                branch_options = CreateBranchOptions(last_partition=(branch_value == "last_partition"))
+                branch_options = CreateBranchOptions(
+                    last_partition=(branch_value == "last_partition")
+                )
 
             branch = get_or_create_branch(
                 {

--- a/tests/test_api_branches_options.py
+++ b/tests/test_api_branches_options.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+import tinybird_sdk.api.branches as branches_module
+from tinybird_sdk.api.branches import CreateBranchOptions, create_branch
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any]):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = ""
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 300
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def test_create_branch_uses_last_partition_data_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    called_urls: list[str] = []
+
+    def fake_fetch(url: str, **_kwargs: Any) -> _FakeResponse:
+        called_urls.append(url)
+        if "/v1/environments?" in url:
+            return _FakeResponse(200, {"job": {"id": "job-1"}})
+        if "/v0/jobs/" in url:
+            return _FakeResponse(200, {"status": "done"})
+        return _FakeResponse(200, {"id": "b1", "name": "x", "created_at": "2024-01-01T00:00:00Z", "token": "p.test"})
+
+    monkeypatch.setattr(branches_module, "tinybird_fetch", fake_fetch)
+    create_branch(
+        {"base_url": "https://api.tinybird.co", "token": "p.test"},
+        "x",
+        options=CreateBranchOptions(last_partition=True),
+    )
+
+    parsed = urlparse(called_urls[0])
+    query = parse_qs(parsed.query)
+    assert parsed.path == "/v1/environments"
+    assert query == {"name": ["x"], "data": ["last_partition"]}
+
+
+def test_create_branch_without_options_keeps_default_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    called_urls: list[str] = []
+
+    def fake_fetch(url: str, **_kwargs: Any) -> _FakeResponse:
+        called_urls.append(url)
+        if "/v1/environments?" in url:
+            return _FakeResponse(200, {"job": {"id": "job-1"}})
+        if "/v0/jobs/" in url:
+            return _FakeResponse(200, {"status": "done"})
+        return _FakeResponse(200, {"id": "b1", "name": "x", "created_at": "2024-01-01T00:00:00Z", "token": "p.test"})
+
+    monkeypatch.setattr(branches_module, "tinybird_fetch", fake_fetch)
+    create_branch({"base_url": "https://api.tinybird.co", "token": "p.test"}, "x")
+
+    parsed = urlparse(called_urls[0])
+    query = parse_qs(parsed.query)
+    assert parsed.path == "/v1/environments"
+    assert query == {"name": ["x"]}
+    assert "data" not in query
+    assert "ignore_datasources" not in query

--- a/tests/test_api_branches_options.py
+++ b/tests/test_api_branches_options.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 
 import tinybird_sdk.api.branches as branches_module
-from tinybird_sdk.api.branches import CreateBranchOptions, create_branch
+from tinybird_sdk.api.branches import CreateBranchOptions, clear_branch, create_branch
 
 
 class _FakeResponse:
@@ -67,3 +67,25 @@ def test_create_branch_without_options_keeps_default_query(monkeypatch: pytest.M
     assert query == {"name": ["x"]}
     assert "data" not in query
     assert "ignore_datasources" not in query
+
+
+def test_clear_branch_forwards_create_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_options: list[CreateBranchOptions | None] = []
+
+    monkeypatch.setattr(branches_module, "delete_branch", lambda *_args, **_kwargs: None)
+
+    def fake_create_branch(_config: dict[str, Any], _name: str, options: CreateBranchOptions | None = None) -> Any:
+        captured_options.append(options)
+        return {"id": "b1", "name": "x", "created_at": "2024-01-01T00:00:00Z", "token": "p.test"}
+
+    monkeypatch.setattr(branches_module, "create_branch", fake_create_branch)
+
+    clear_branch(
+        {"base_url": "https://api.tinybird.co", "token": "p.test"},
+        "x",
+        options=CreateBranchOptions(last_partition=True),
+    )
+
+    assert len(captured_options) == 1
+    assert captured_options[0] is not None
+    assert captured_options[0].last_partition is True

--- a/tests/test_api_branches_options.py
+++ b/tests/test_api_branches_options.py
@@ -40,7 +40,7 @@ def test_create_branch_uses_last_partition_data_query(monkeypatch: pytest.Monkey
     create_branch(
         {"base_url": "https://api.tinybird.co", "token": "p.test"},
         "x",
-        options=CreateBranchOptions(last_partition=True),
+        options=CreateBranchOptions(branch_data_mode="last_partition"),
     )
 
     parsed = urlparse(called_urls[0])
@@ -89,9 +89,9 @@ def test_clear_branch_forwards_create_options(monkeypatch: pytest.MonkeyPatch) -
     clear_branch(
         {"base_url": "https://api.tinybird.co", "token": "p.test"},
         "x",
-        options=CreateBranchOptions(last_partition=True),
+        options=CreateBranchOptions(branch_data_mode="last_partition"),
     )
 
     assert len(captured_options) == 1
     assert captured_options[0] is not None
-    assert captured_options[0].last_partition is True
+    assert captured_options[0].branch_data_mode == "last_partition"

--- a/tests/test_api_branches_options.py
+++ b/tests/test_api_branches_options.py
@@ -32,7 +32,9 @@ def test_create_branch_uses_last_partition_data_query(monkeypatch: pytest.Monkey
             return _FakeResponse(200, {"job": {"id": "job-1"}})
         if "/v0/jobs/" in url:
             return _FakeResponse(200, {"status": "done"})
-        return _FakeResponse(200, {"id": "b1", "name": "x", "created_at": "2024-01-01T00:00:00Z", "token": "p.test"})
+        return _FakeResponse(
+            200, {"id": "b1", "name": "x", "created_at": "2024-01-01T00:00:00Z", "token": "p.test"}
+        )
 
     monkeypatch.setattr(branches_module, "tinybird_fetch", fake_fetch)
     create_branch(
@@ -56,7 +58,9 @@ def test_create_branch_without_options_keeps_default_query(monkeypatch: pytest.M
             return _FakeResponse(200, {"job": {"id": "job-1"}})
         if "/v0/jobs/" in url:
             return _FakeResponse(200, {"status": "done"})
-        return _FakeResponse(200, {"id": "b1", "name": "x", "created_at": "2024-01-01T00:00:00Z", "token": "p.test"})
+        return _FakeResponse(
+            200, {"id": "b1", "name": "x", "created_at": "2024-01-01T00:00:00Z", "token": "p.test"}
+        )
 
     monkeypatch.setattr(branches_module, "tinybird_fetch", fake_fetch)
     create_branch({"base_url": "https://api.tinybird.co", "token": "p.test"}, "x")
@@ -74,7 +78,9 @@ def test_clear_branch_forwards_create_options(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(branches_module, "delete_branch", lambda *_args, **_kwargs: None)
 
-    def fake_create_branch(_config: dict[str, Any], _name: str, options: CreateBranchOptions | None = None) -> Any:
+    def fake_create_branch(
+        _config: dict[str, Any], _name: str, options: CreateBranchOptions | None = None
+    ) -> Any:
         captured_options.append(options)
         return {"id": "b1", "name": "x", "created_at": "2024-01-01T00:00:00Z", "token": "p.test"}
 

--- a/tests/test_cli_branch_config.py
+++ b/tests/test_cli_branch_config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tinybird_sdk.cli.config import _resolve_branch_data_on_create, load_config
+
+
+def test_branch_data_on_create_last_partition() -> None:
+    assert _resolve_branch_data_on_create({"branch_data_on_create": "last_partition"}) == "last_partition"
+
+
+def test_branch_data_on_create_missing_returns_none() -> None:
+    assert _resolve_branch_data_on_create({}) == "last_partition"
+
+
+def test_branch_data_on_create_empty_defaults_to_last_partition() -> None:
+    assert _resolve_branch_data_on_create({"branch_data_on_create": "   "}) == "last_partition"
+
+
+def test_branch_data_on_create_all_partitions_disabled() -> None:
+    with pytest.raises(ValueError, match="disabled"):
+        _resolve_branch_data_on_create({"branch_data_on_create": "all_partitions"})
+
+
+def test_branch_data_on_create_invalid_value() -> None:
+    with pytest.raises(ValueError, match="Invalid branch_data_on_create"):
+        _resolve_branch_data_on_create({"branch_data_on_create": "invalid"})
+
+
+def test_branch_data_on_create_non_string() -> None:
+    with pytest.raises(ValueError, match="must be a string"):
+        _resolve_branch_data_on_create({"branch_data_on_create": 1})
+
+
+def test_load_config_warns_when_local_mode_uses_branch_data(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "tinybird.config.json").write_text(
+        json.dumps(
+            {
+                "include": ["lib/datasources.py"],
+                "token": "p.test",
+                "base_url": "https://api.tinybird.co",
+                "dev_mode": "local",
+                "branch_data_on_create": "last_partition",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    load_config(str(project))
+    captured = capsys.readouterr()
+    assert "branch_data_on_create is set" in captured.out

--- a/tests/test_cli_branch_config.py
+++ b/tests/test_cli_branch_config.py
@@ -5,37 +5,50 @@ from pathlib import Path
 
 import pytest
 
-from tinybird_sdk.cli.config import _resolve_branch_data_on_create, load_config
+from tinybird_sdk.cli.config import _resolve_branch_data_mode, load_config
 
 
-def test_branch_data_on_create_last_partition() -> None:
-    assert _resolve_branch_data_on_create({"branch_data_on_create": "last_partition"}) == "last_partition"
+def test_branch_data_mode_last_partition() -> None:
+    mode, explicit = _resolve_branch_data_mode({"branch_data_mode": "last_partition"})
+    assert mode == "last_partition"
+    assert explicit is True
 
 
-def test_branch_data_on_create_missing_returns_none() -> None:
-    assert _resolve_branch_data_on_create({}) == "last_partition"
+def test_branch_data_mode_missing_defaults_to_last_partition() -> None:
+    mode, explicit = _resolve_branch_data_mode({})
+    assert mode == "last_partition"
+    assert explicit is False
 
 
-def test_branch_data_on_create_empty_defaults_to_last_partition() -> None:
-    assert _resolve_branch_data_on_create({"branch_data_on_create": "   "}) == "last_partition"
+def test_branch_data_mode_empty_defaults_to_last_partition() -> None:
+    mode, explicit = _resolve_branch_data_mode({"branch_data_mode": "   "})
+    assert mode == "last_partition"
+    assert explicit is False
 
 
-def test_branch_data_on_create_all_partitions_disabled() -> None:
-    with pytest.raises(ValueError, match="disabled"):
-        _resolve_branch_data_on_create({"branch_data_on_create": "all_partitions"})
+def test_branch_data_mode_rejects_legacy_key() -> None:
+    with pytest.raises(ValueError, match="renamed to `branch_data_mode`"):
+        _resolve_branch_data_mode({"branch_data_on_create": "last_partition"})
 
 
-def test_branch_data_on_create_invalid_value() -> None:
-    with pytest.raises(ValueError, match="Invalid branch_data_on_create"):
-        _resolve_branch_data_on_create({"branch_data_on_create": "invalid"})
+def test_branch_data_mode_rejects_all_partitions() -> None:
+    with pytest.raises(ValueError, match="Invalid branch_data_mode"):
+        _resolve_branch_data_mode({"branch_data_mode": "all_partitions"})
 
 
-def test_branch_data_on_create_non_string() -> None:
+def test_branch_data_mode_invalid_value() -> None:
+    with pytest.raises(ValueError, match="Invalid branch_data_mode"):
+        _resolve_branch_data_mode({"branch_data_mode": "invalid"})
+
+
+def test_branch_data_mode_non_string() -> None:
     with pytest.raises(ValueError, match="must be a string"):
-        _resolve_branch_data_on_create({"branch_data_on_create": 1})
+        _resolve_branch_data_mode({"branch_data_mode": 1})
 
 
-def test_load_config_warns_when_local_mode_uses_branch_data(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_load_config_warns_when_local_mode_explicit_branch_data_mode(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     project = tmp_path / "project"
     project.mkdir()
     (project / "tinybird.config.json").write_text(
@@ -45,7 +58,7 @@ def test_load_config_warns_when_local_mode_uses_branch_data(tmp_path: Path, caps
                 "token": "p.test",
                 "base_url": "https://api.tinybird.co",
                 "dev_mode": "local",
-                "branch_data_on_create": "last_partition",
+                "branch_data_mode": "last_partition",
             }
         ),
         encoding="utf-8",
@@ -53,4 +66,26 @@ def test_load_config_warns_when_local_mode_uses_branch_data(tmp_path: Path, caps
 
     load_config(str(project))
     captured = capsys.readouterr()
-    assert "branch_data_on_create is set" in captured.out
+    assert "branch_data_mode is set" in captured.out
+
+
+def test_load_config_does_not_warn_when_branch_data_mode_is_implicit(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "tinybird.config.json").write_text(
+        json.dumps(
+            {
+                "include": ["lib/datasources.py"],
+                "token": "p.test",
+                "base_url": "https://api.tinybird.co",
+                "dev_mode": "local",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    load_config(str(project))
+    captured = capsys.readouterr()
+    assert "branch_data_mode is set" not in captured.out

--- a/tests/test_client_parity.py
+++ b/tests/test_client_parity.py
@@ -43,6 +43,8 @@ def test_client_query_and_api_error_mapping(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_client_branch_context_uses_branch_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
     monkeypatch.setattr(client_base, "is_preview_environment", lambda: False)
     monkeypatch.setattr(
         client_base,
@@ -51,13 +53,16 @@ def test_client_branch_context_uses_branch_token(monkeypatch: pytest.MonkeyPatch
             "git_branch": "feature/alpha",
             "tinybird_branch": "feature_alpha",
             "is_main_branch": False,
+            "dev_mode": "branch",
+            "branch_data_mode": "last_partition",
         },
     )
-    monkeypatch.setattr(
-        client_base,
-        "get_or_create_branch",
-        lambda *_args, **_kwargs: {"token": "branch_token"},
-    )
+
+    def fake_get_or_create_branch(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {"token": "branch_token"}
+
+    monkeypatch.setattr(client_base, "get_or_create_branch", fake_get_or_create_branch)
 
     client = TinybirdClient(
         {
@@ -71,6 +76,7 @@ def test_client_branch_context_uses_branch_token(monkeypatch: pytest.MonkeyPatch
     assert context["token"] == "branch_token"
     assert context["is_branch_token"] is True
     assert context["branch_name"] == "feature_alpha"
+    assert captured["options"].last_partition is True
 
 
 def test_tokens_namespace_wraps_token_api_errors(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_client_parity.py
+++ b/tests/test_client_parity.py
@@ -76,7 +76,7 @@ def test_client_branch_context_uses_branch_token(monkeypatch: pytest.MonkeyPatch
     assert context["token"] == "branch_token"
     assert context["is_branch_token"] is True
     assert context["branch_name"] == "feature_alpha"
-    assert captured["options"].last_partition is True
+    assert captured["options"].branch_data_mode == "last_partition"
 
 
 def test_tokens_namespace_wraps_token_api_errors(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1190,7 +1190,7 @@ wheels = [
 
 [[package]]
 name = "tinybird-sdk"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "tinybird" },

--- a/uv.lock
+++ b/uv.lock
@@ -1205,7 +1205,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "tinybird", specifier = "==4.6.0" }]
+requires-dist = [{ name = "tinybird", specifier = ">=4.6.0,<4.7.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This MR releases `tinybird-sdk-python` version `0.1.11` and aligns the SDK with Tinybird CLI `4.6.1` branch-management behavior.

### Changes
- Bumped package version to `0.1.11`.
- Updated bundled CLI dependency to `tinybird==4.6.1`.
- Updated `CHANGELOG.md` with release notes for `0.1.11`.

### Included CLI behavior updates (4.6.1)
- `branch_data_on_create` is replaced by `branch_data_mode`; legacy key now raises an explicit migration error.
- `branch_data_mode` now only accepts `last_partition` as user-facing value.
- In `dev_mode=local`, branch data mode warnings are shown only when `branch_data_mode` is explicitly set in `tinybird.config.json`.
- `tinybird branch create` and `tinybird branch clear` now show a deprecation warning (instead of failing) when `--ignore-datasource` is passed, then continue by ignoring the flag.

### Why
To keep Python SDK users aligned with current CLI semantics and avoid failures in branch flows that now require warning-and-continue behavior.